### PR TITLE
Allow single-file generation; add warnings about drive space

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Unique File Generator (F# Version)
 
-- Quickly and easily creates an arbitrary number of unique (by name and content) files
-- Accepts optional parameters to customize files according to your needs
+- Quickly and easily create an arbitrary number of unique (by name and content) files
+- Use optional parameters to customize files according to your needs
 - Requirement: .NET 9 (or higher) runtime
 
 ## But... why?
@@ -42,10 +42,10 @@ Flag | Description
 dotnet run -- 50,000 -p Random-
 ```
 
-Creates 50,000 files, each named similarly to "Random-##########...", in a subfolder named "output". There are no extensions.
+Creates 50,000 files, each named similarly to "Random-##########", in a subfolder named "output". No files have extensions.
 
 ```sh
-dotnet run -- 100 -p "TEST " -b 10 -e txt -o "My Output Folder" -s 1000000 -d 1000
+dotnet run -- 100 -p "TEST " -b 7 -e txt -o "My Output Folder" -s 1000000 -d 1000
 ```
 
-Creates 100 1MB files, each named similarly to "TEST ##########.txt", with a 1-second break between each file's creation, in a subfolder called "My Output Folder".
+Creates 100 1MB files, each named similarly to "TEST #######.txt", with a 1-second break between each file's creation, in a subfolder called "My Output Folder".

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In a previous position, I actually had use for such a utility once. However, I o
 
 At the minimum, you must specify the number of files you want to generate with the default options. This should be a single positive integer (with optional commas or underscores).
 
-```
+```sh
 dotnet run -- 1000
 ```
 
@@ -38,13 +38,13 @@ Flag | Description
 > [!NOTE]
 > `--` is needed after `dotnet run` to signal that the arguments are for this application and not the `dotnet` command.
 
-```
+```sh
 dotnet run -- 50,000 -p Random-
 ```
 
 Creates 50,000 files, each named similarly to "Random-##########...", in a subfolder named "output". There are no extensions.
 
-```
+```sh
 dotnet run -- 100 -p "TEST " -b 10 -e txt -o "My Output Folder" -s 1000000 -d 1000
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ In a previous position, I actually had use for such a utility once. However, I o
 
 ## Usage
 
+> [!CAUTION]
+> This application does not (yet) verify remaining drive space, so ensure your arguments are appropriate to avoid unintentionally filling your drive.
+
 At the minimum, you must specify the number of files you want to generate with the default options. This should be a single positive integer (with optional commas or underscores).
 
 ```

--- a/src/UniqueFileGenerator.Console/ArgParser.fs
+++ b/src/UniqueFileGenerator.Console/ArgParser.fs
@@ -87,7 +87,7 @@ module ArgValidation =
 
         match tryParseInt strippedArg with
         | Some c ->
-            if c > 1 then Ok c
+            if c > 0 then Ok c
             else Error (FileCountInvalid rawArg)
         | None -> Error (FileCountInvalid rawArg)
 

--- a/src/UniqueFileGenerator.Console/Help.fs
+++ b/src/UniqueFileGenerator.Console/Help.fs
@@ -12,7 +12,8 @@ module Help =
             "• Homepage: https://github.com/codeconscious/unique-file-generator-fsharp"
         ]
         [
-            "Usage:"
+            "Caution: This application does not (yet) verify remaining drive space, so ensure your arguments"
+            "         are appropriate to avoid unintentionally filling your drive."
         ]
         [
             "At the minimum, you must specify the number of files to generate with the default options."


### PR DESCRIPTION
- Allow `1` as a valid file count (What's a project launch without an off-by-one error? 😅)
- Add a warning about drive space to the README file and in-app help