### PR TITLE
Add FsToolkit.ErrorHandling package

### DIFF
--- a/src/UniqueFileGenerator.Console/ArgParser.fs
+++ b/src/UniqueFileGenerator.Console/ArgParser.fs
@@ -1,6 +1,7 @@
 namespace UniqueFileGenerator.Console
 
 open System
+open FsToolkit.ErrorHandling
 
 module ArgValidation =
     module Types =
@@ -41,15 +42,6 @@ module ArgValidation =
             | UnsupportedFlags
             | DirectoryMissing of string
 
-        type ResultBuilder() =
-            member this.Bind(m, f) =
-                match m with
-                | Error e -> Error e
-                | Ok a -> f a
-
-            member this.Return(x) =
-                Ok x
-
     open Types
 
     let private empty = String.Empty
@@ -61,8 +53,6 @@ module ArgValidation =
           OutputDirectory = "output"
           Size = None
           Delay = 0 }
-
-    let private result = ResultBuilder()
 
     let private tryParseInt (input: string) =
         match Int32.TryParse(input.Replace(",", empty)) with

--- a/src/UniqueFileGenerator.Console/UniqueFileGenerator.Console.fsproj
+++ b/src/UniqueFileGenerator.Console/UniqueFileGenerator.Console.fsproj
@@ -16,6 +16,7 @@
 
     <ItemGroup>
       <PackageReference Include="CodeConscious.Startwatch" Version="1.0.0" />
+      <PackageReference Include="FsToolkit.ErrorHandling" Version="4.18.0" />
       <PackageReference Include="xunit" Version="2.9.3" />
     </ItemGroup>
 


### PR DESCRIPTION
I learned about this package last weekend. For a start, it allows me to omit the `ResultBuilder` I manually created to enable my `result` computation expression.

I'll have to explore this package's power further later. I think there's probably a lot there.