### PR TITLE
Add `--help` flag

### DIFF
--- a/src/UniqueFileGenerator.Console/Help.fs
+++ b/src/UniqueFileGenerator.Console/Help.fs
@@ -1,9 +1,16 @@
 namespace UniqueFileGenerator.Console
 
-open Printing
+open System
 open ArgValidation
+open Printing
 
 module Help =
+    let private helpFlag = "--help"
+
+    let wasRequested (args: string array) =
+        args.Length > 0 &&
+        args[0].Trim().Equals(helpFlag, StringComparison.InvariantCultureIgnoreCase)
+
     let private textBlocks = [
         [
             "Unique File Generator"
@@ -59,9 +66,9 @@ module Help =
 
     let print () =
         textBlocks
-        |> List.iter (fun blockLines ->
-            printEmptyLine ()
+        |> List.iteri (fun i blockLines ->
+            if i = 0 then () else printEmptyLine ()
             blockLines |> List.iter printLine)
 
     let suggest () =
-        printfn "Pass \"--help\" to see the instructions."
+        printfn "Pass \"--help\" to see the program instructions."

--- a/src/UniqueFileGenerator.Console/Help.fs
+++ b/src/UniqueFileGenerator.Console/Help.fs
@@ -4,6 +4,7 @@ open System
 open ArgValidation
 open Printing
 
+[<RequireQualifiedAccess>]
 module Help =
     let private helpFlag = "--help"
 

--- a/src/UniqueFileGenerator.Console/Help.fs
+++ b/src/UniqueFileGenerator.Console/Help.fs
@@ -62,3 +62,6 @@ module Help =
         |> List.iter (fun blockLines ->
             printEmptyLine ()
             blockLines |> List.iter printLine)
+
+    let suggest () =
+        printfn "Pass \"--help\" to see the instructions."

--- a/src/UniqueFileGenerator.Console/Program.fs
+++ b/src/UniqueFileGenerator.Console/Program.fs
@@ -1,30 +1,35 @@
 ﻿namespace UniqueFileGenerator.Console
 
+open ArgValidation
+open ArgValidation.Types
+open Errors
+open Printing
+open Io
 open FsToolkit.ErrorHandling
 
 module Main =
-    open ArgValidation
-    open ArgValidation.Types
-    open Printing
-    open Io
-    open Errors
-
     [<EntryPoint>]
     let main rawArgs =
         let watch = Startwatch.Library.Watch()
 
         let run (rawArgs: string array) =
-            result {
-                let! args = validate rawArgs
-                let! _ = verifyDirectory args.Options.OutputDirectory
-                return generateFiles args
-            }
+            if rawArgs.Length > 1 && rawArgs[0].Trim() = "--help"
+                then
+                    Help.print()
+                    Ok ()
+            else
+                result {
+
+                        let! args = validate rawArgs
+                        let! _ = verifyDirectory args.Options.OutputDirectory
+                        return generateFiles args
+                }
 
         match run rawArgs with
         | Ok _ ->
             printLine $"Done after %s{watch.ElapsedFriendly}"
             0
         | Error e ->
-            e |> getMessage |> printError
-            Help.print()
+            printError <| getMessage e
+            Help.suggest()
             1

--- a/src/UniqueFileGenerator.Console/Program.fs
+++ b/src/UniqueFileGenerator.Console/Program.fs
@@ -13,23 +13,21 @@ module Main =
         let watch = Startwatch.Library.Watch()
 
         let run (rawArgs: string array) =
-            if rawArgs.Length > 1 && rawArgs[0].Trim() = "--help"
-                then
-                    Help.print()
-                    Ok ()
-            else
-                result {
+            result {
+                let! args = validate rawArgs
+                let! _ = verifyDirectory args.Options.OutputDirectory
+                return generateFiles args
+            }
 
-                        let! args = validate rawArgs
-                        let! _ = verifyDirectory args.Options.OutputDirectory
-                        return generateFiles args
-                }
-
-        match run rawArgs with
-        | Ok _ ->
-            printLine $"Done after %s{watch.ElapsedFriendly}"
+        if Help.wasRequested rawArgs then
+            Help.print ()
             0
-        | Error e ->
-            printError <| getMessage e
-            Help.suggest()
-            1
+        else
+            match run rawArgs with
+            | Ok _ ->
+                printLine $"Done after %s{watch.ElapsedFriendly}"
+                0
+            | Error e ->
+                printError <| getMessage e
+                Help.suggest ()
+                1


### PR DESCRIPTION
- Allow users to pass `--help` to show the program instructions
- When an error is returned, instead of printing the entire instructions, just suggest the user uses `--help`