### PR TITLE
Confirm large operations

### DIFF
--- a/src/UniqueFileGenerator.Console/Arguments/ArgumentTypes.fs
+++ b/src/UniqueFileGenerator.Console/Arguments/ArgumentTypes.fs
@@ -15,7 +15,7 @@ module ArgTypes =
     let private tryParseIntInRange (floor, ceiling) text =
         text
         |> parseInRange (floor, ceiling)
-        |> Result.mapError (fun _ -> InvalidNumber (text, floor, ceiling))
+        |> Result.mapError (fun _ -> ParseNumberFailure (text, floor, ceiling))
 
     type FileCount = private FileCount of int with
         static member val AllowedRange = 1, Int32.MaxValue
@@ -25,9 +25,9 @@ module ArgTypes =
             |> stripSeparators
             |> parseInRange FileCount.AllowedRange
             |> Result.mapError (fun _ ->
-                InvalidNumber (text,
-                               fst FileCount.AllowedRange,
-                               snd FileCount.AllowedRange))
+                ParseNumberFailure (text,
+                                    fst FileCount.AllowedRange,
+                                    snd FileCount.AllowedRange))
             |> Result.map FileCount
 
         member this.Value = let (FileCount count) = this in count

--- a/src/UniqueFileGenerator.Console/Arguments/ArgumentTypes.fs
+++ b/src/UniqueFileGenerator.Console/Arguments/ArgumentTypes.fs
@@ -25,9 +25,7 @@ module ArgTypes =
             |> stripSeparators
             |> parseInRange FileCount.AllowedRange
             |> Result.mapError (fun _ ->
-                ParseNumberFailure (text,
-                                    fst FileCount.AllowedRange,
-                                    snd FileCount.AllowedRange))
+                ParseNumberFailure (text, fst FileCount.AllowedRange, snd FileCount.AllowedRange))
             |> Result.map FileCount
 
         member this.Value = let (FileCount count) = this in count
@@ -125,10 +123,11 @@ module ArgTypes =
         private
             { fileCount: int
               options: Options }
+
         member x.FileCount = x.fileCount
         member x.Options = x.options
 
-        static member Create(count: FileCount, options: Options) =
+        static member Create (count: FileCount, options: Options) =
             { fileCount = count.Value
               options =
                 { Prefix = options.Prefix

--- a/src/UniqueFileGenerator.Console/Errors.fs
+++ b/src/UniqueFileGenerator.Console/Errors.fs
@@ -13,6 +13,7 @@ module Errors =
         | DirectoryMissing of string
         | DriveSpaceConfirmationFailure
         | DriveSpaceInsufficient of Needed: string * Actual: string
+        | CancelledByUser
         | UnknownError of string
 
     let getMessage error =
@@ -28,5 +29,6 @@ module Errors =
         | DriveSpaceConfirmationFailure -> "Could not confirm available drive space."
         | DriveSpaceInsufficient (needed, actual) ->
             $"Insufficient drive space. Though %s{needed} is necessary, only %s{actual} is available."
+        | CancelledByUser -> "Cancelled."
         | UnknownError e -> e
 

--- a/src/UniqueFileGenerator.Console/Errors.fs
+++ b/src/UniqueFileGenerator.Console/Errors.fs
@@ -29,6 +29,6 @@ module Errors =
         | DriveSpaceConfirmationFailure -> "Could not confirm available drive space."
         | DriveSpaceInsufficient (needed, actual) ->
             $"Insufficient drive space. Though %s{needed} is necessary, only %s{actual} is available."
-        | IoError e -> e
+        | IoError e -> $"IO error: %s{e}"
         | CancelledByUser -> "Cancelled."
 

--- a/src/UniqueFileGenerator.Console/Errors.fs
+++ b/src/UniqueFileGenerator.Console/Errors.fs
@@ -13,8 +13,8 @@ module Errors =
         | DirectoryMissing of string
         | DriveSpaceConfirmationFailure
         | DriveSpaceInsufficient of Needed: string * Actual: string
+        | IoError of string
         | CancelledByUser
-        | UnknownError of string
 
     let getMessage error =
         match error with
@@ -29,6 +29,6 @@ module Errors =
         | DriveSpaceConfirmationFailure -> "Could not confirm available drive space."
         | DriveSpaceInsufficient (needed, actual) ->
             $"Insufficient drive space. Though %s{needed} is necessary, only %s{actual} is available."
+        | IoError e -> e
         | CancelledByUser -> "Cancelled."
-        | UnknownError e -> e
 

--- a/src/UniqueFileGenerator.Console/Errors.fs
+++ b/src/UniqueFileGenerator.Console/Errors.fs
@@ -9,7 +9,7 @@ module Errors =
         | MalformedFlags
         | UnsupportedFlags
         | DuplicateFlags
-        | InvalidNumber of Arg: string * Floor: int * Ceiling: int
+        | ParseNumberFailure of Arg: string * Floor: int * Ceiling: int
         | DirectoryMissing of string
         | DriveSpaceConfirmationFailure
         | DriveSpaceInsufficient of Needed: string * Actual: string
@@ -23,7 +23,7 @@ module Errors =
         | MalformedFlags -> "Malformed flag(s) found."
         | UnsupportedFlags -> "Unsupported flag(s) found."
         | DuplicateFlags -> "Duplicate option flag(s) found. Each can only be used once."
-        | InvalidNumber (x, f, c) ->
+        | ParseNumberFailure (x, f, c) ->
             $"Could not parse \"%s{x}\" to an integer between %s{formatInt f} and %s{formatInt c}, inclusive."
         | DirectoryMissing e -> $"Directory \"%s{e}\" was not found."
         | DriveSpaceConfirmationFailure -> "Could not confirm available drive space."

--- a/src/UniqueFileGenerator.Console/Io.fs
+++ b/src/UniqueFileGenerator.Console/Io.fs
@@ -48,7 +48,11 @@ module Io =
             let isLargeRatio = ratio > warningRatio
 
             let confirm () =
-                Console.Write($"This operation requires %s{formatBytes necessarySpace}, %g{ratio * 100.0}%% of remaining drive space. Continue? (Y/n)  ")
+                Console.Write(
+                    sprintf "This operation requires %s, which is %.2f%% of remaining drive space. Continue? (Y/n)  "
+                        (formatBytes necessarySpace)
+                        (ratio * 100.0))
+
                 let reply = Console.ReadLine().Trim()
 
                 [| "y"; "yes" |]
@@ -69,12 +73,10 @@ module Io =
                 let usableFreeSpace = driveInfo.AvailableFreeSpace - driveSpaceToKeepAvailable
 
                 if necessarySpace > usableFreeSpace
-                then Error <| DriveSpaceInsufficient (formatBytes necessarySpace,
-                                                      formatBytes usableFreeSpace)
-                else
-                    if confirmContinueDespiteLargeSize usableFreeSpace
-                    then Ok (formatBytes necessarySpace)
-                    else Error CancelledByUser
+                then Error (DriveSpaceInsufficient (formatBytes necessarySpace, formatBytes usableFreeSpace))
+                elif confirmContinueDespiteLargeSize usableFreeSpace
+                then Ok (formatBytes necessarySpace)
+                else Error CancelledByUser
         with
             | e -> Error (IoError $"%s{e.Message}")
 

--- a/src/UniqueFileGenerator.Console/Io.fs
+++ b/src/UniqueFileGenerator.Console/Io.fs
@@ -76,7 +76,7 @@ module Io =
                     then Ok (formatBytes necessarySpace)
                     else Error CancelledByUser
         with
-            | e -> Error (UnknownError $"%s{e.Message}")
+            | e -> Error (IoError $"%s{e.Message}")
 
     let private createFile directory fileName (contents: string) =
         try

--- a/src/UniqueFileGenerator.Console/Io.fs
+++ b/src/UniqueFileGenerator.Console/Io.fs
@@ -25,7 +25,7 @@ module Io =
 
     let verifyDriveSpace (args: Args) =
         let bytesToKeepAvailable = 536_870_912L // 0.5 GB
-        let largeOperationBorderline = 1073741824L // 1 GB
+        let largeOperationBorderline = 1_073_741_824L // 1 GB
 
         let necessaryDriveSpace =
             let singleFileSize =
@@ -38,13 +38,13 @@ module Io =
 
             singleFileSize * int64 args.FileCount // Rough estimation
 
-        let confirmShouldContinueDespiteLargeSize () =
+        let askContinueDespiteLargeSize () =
             let confirm () =
-                Console.Write($"This operation will take %d{necessaryDriveSpace} bytes. Continue? (Y/n)  ")
-                let answer = Console.ReadLine()
+                Console.Write($"This operation will require %s{formatBytes necessaryDriveSpace} of drive space. Continue? (Y/n)  ")
+                let reply = Console.ReadLine()
 
                 [| "y"; "yes" |]
-                |> Array.exists (fun x -> answer.Equals(x.Trim(), StringComparison.InvariantCultureIgnoreCase))
+                |> Array.exists (fun x -> reply.Equals(x.Trim(), StringComparison.InvariantCultureIgnoreCase))
 
             if necessaryDriveSpace > largeOperationBorderline
             then confirm ()
@@ -64,11 +64,11 @@ module Io =
                 then Error <| DriveSpaceInsufficient (formatBytes necessaryDriveSpace,
                                                       formatBytes usableFreeSpace)
                 else
-                    if confirmShouldContinueDespiteLargeSize ()
+                    if askContinueDespiteLargeSize ()
                     then Ok (formatBytes necessaryDriveSpace)
-                    else Error (UnknownError "Cancelled") // TODO: Make new ErrorType type.
+                    else Error CancelledByUser
         with
-            | e -> Error (UnknownError $"%s{e.Message}") // TODO: Make new ErrorType type.
+            | e -> Error (UnknownError $"%s{e.Message}")
 
     let verifyDirectory dir =
         match Directory.Exists dir with

--- a/src/UniqueFileGenerator.Console/Program.fs
+++ b/src/UniqueFileGenerator.Console/Program.fs
@@ -18,8 +18,8 @@ module Main =
                 do! verifyDirectory args.Options.OutputDirectory
                 let! spaceNeeded = verifyDriveSpace args
 
-                printLine $"This operation will use approximately %s{spaceNeeded} of drive space."
-                return generateFiles args
+                generateFiles args
+                return spaceNeeded
             }
 
         if Help.wasRequested rawArgs then
@@ -27,8 +27,8 @@ module Main =
             0
         else
             match run rawArgs with
-            | Ok _ ->
-                printLine $"Done after %s{watch.ElapsedFriendly}"
+            | Ok spaceUsed ->
+                printLine $"Done after %s{watch.ElapsedFriendly}. Used approximately %s{spaceUsed} of drive space."
                 0
             | Error e ->
                 printError <| getMessage e

--- a/src/UniqueFileGenerator.Console/UniqueFileGenerator.Console.fsproj
+++ b/src/UniqueFileGenerator.Console/UniqueFileGenerator.Console.fsproj
@@ -4,6 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net9.0</TargetFramework>
         <WarnOn>3579</WarnOn>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/UniqueFileGenerator.Tests/ArgParserTests.fs
+++ b/src/UniqueFileGenerator.Tests/ArgParserTests.fs
@@ -64,21 +64,21 @@ let ``Appropriate error when invalid arg count (second pair incomplete)`` () =
 [<Fact>]
 let ``Appropriate error when invalid file count`` () =
     let args = [| "notNumeric" |]
-    let expected = Error <| InvalidNumber(args[0], 1, Int32.MaxValue)
+    let expected = Error <| ParseNumberFailure(args[0], 1, Int32.MaxValue)
     let actual = validate args
     Assert.Equal(expected, actual)
 
 [<Fact>]
 let ``Appropriate error when negative file count`` () =
     let args = [| "-1" |]
-    let expected = Error <| InvalidNumber(args[0], 1, Int32.MaxValue)
+    let expected = Error <| ParseNumberFailure(args[0], 1, Int32.MaxValue)
     let actual = validate args
     Assert.Equal(expected, actual)
 
 [<Fact>]
 let ``Appropriate error when zero file count`` () =
     let args = [| "0" |]
-    let expected = Error <| InvalidNumber(args[0], 1, Int32.MaxValue)
+    let expected = Error <| ParseNumberFailure(args[0], 1, Int32.MaxValue)
     let actual = validate args
     Assert.Equal(expected, actual)
 


### PR DESCRIPTION
- When the drive space necessary is over a certain limit, ask the user to confirm the operation before proceeding
- Show the drive space used when done
- Enable `TreatWarningsAsErrors` in the Console project file