### PR TITLE
Use existing float formatter

### DIFF
--- a/src/UniqueFileGenerator.Console/Io.fs
+++ b/src/UniqueFileGenerator.Console/Io.fs
@@ -49,9 +49,9 @@ module Io =
 
             let confirm () =
                 Console.Write(
-                    sprintf "This operation requires %s, which is %.2f%% of remaining drive space. Continue? (Y/n)  "
-                        (formatBytes necessarySpace)
-                        (ratio * 100.0))
+                    sprintf "This operation requires %s, which is %s%% of remaining drive space. Continue? (Y/n)  "
+                        (necessarySpace |> formatBytes)
+                        (ratio * 100.0 |> formatFloat))
 
                 let reply = Console.ReadLine().Trim()
 

--- a/src/UniqueFileGenerator.Console/Utilities.fs
+++ b/src/UniqueFileGenerator.Console/Utilities.fs
@@ -11,7 +11,7 @@ module Utilities =
         i.ToString("#,##0", CultureInfo.InvariantCulture)
 
     let formatFloat (f: float) : string =
-        f.ToString("#,##0.##", CultureInfo.InvariantCulture)
+        f.ToString("#,##0.00", CultureInfo.InvariantCulture)
 
     let inline (>=<) a (floor, ceiling) = a >= floor && a <= ceiling
 


### PR DESCRIPTION
In #14, I forgot that I have a float formatter. 😅

Updated text prompt:

```
$ dotnet run -- 23000 -s 9999999      
This operation requires 214.20 GB, which is 88.60% of remaining drive space. Continue? (Y/n) 
```